### PR TITLE
Update website_webhook action to the use of discussions

### DIFF
--- a/.github/workflows/website_webhook.yml
+++ b/.github/workflows/website_webhook.yml
@@ -26,8 +26,8 @@ jobs:
     id: summary
     run: |
       echo "${{ github.event.discussion.body }}" > body.txt
-      sed -nr 's/.*### Brief description of the announcement(.*)### Detailed context.*/\1/p' <body.txt >body.txt
-      echo "::set-output name=body::$(cat body.txt)"
+      sed -nr 's/.*### Brief description of the announcement(.*)### Detailed context.*/\1/p' <body.txt >summary.txt
+      echo "::set-output name=body::$(cat summary.txt)"
 
   - name: Fetch description
     id: description

--- a/.github/workflows/website_webhook.yml
+++ b/.github/workflows/website_webhook.yml
@@ -12,21 +12,10 @@ jobs:
   - name: Fetch announcement
     id: announcement
     run: |
-      category="${{ github.event.discussion.category.name }}"
-      title="${{ github.event.discussion.title }}"
-      body="${{ github.event.discussion.body }}"
+      echo "::set-output name=category::${{ github.event.discussion.category.name }}"
+      echo "::set-output name=title::${{ github.event.discussion.title }}"
+      echo "::set-output name=body::${{ github.event.discussion.body }}"
       
-      echo "::set-output name=title::${title}"
-      echo "::set-output name=summary::${body:0:500}"
-      echo "::set-output name=description::${body}"
-      
-      if [[ "${category}" == "Releases" ]]
-      then
-        echo "::set-output name=is_release::true"
-      else
-        echo "::set-output name=is_release::false"
-      fi      
-
   - name: Fetch current date
     id: date
     run: |
@@ -39,4 +28,4 @@ jobs:
       token: ${{ secrets.CODE_REPO_ACCESS_TOKEN }}
       repository: icub-tech-iit/code
       event-type: announcement_launched
-      client-payload: '{"description": ${{ steps.announcement.outputs.description }}, "id": "${{ steps.date.outputs.date }}", "title": ${{ steps.announcement.outputs.title }}, "date": "${{ steps.date.outputs.date_spelled }}", "summary": "${{ steps.announcement.outputs.summary }}", "image": "???", "type" : "announcement_launched", "release": "${{ steps.announcement.outputs.is_release }}"}'
+      client-payload: '{"description": "${{ steps.announcement.outputs.body }}", "id": "${{ steps.date.outputs.date }}", "title": "${{ steps.announcement.outputs.title }}", "date": "${{ steps.date.outputs.date_spelled }}", "image": "???", "type" : "announcement_launched", "category": "${{ steps.announcement.outputs.category }}"}'

--- a/.github/workflows/website_webhook.yml
+++ b/.github/workflows/website_webhook.yml
@@ -1,67 +1,49 @@
-name: auto-upload announcements to website
+name: Auto-upload Distro announcements to Bazaar
 
 on:
-  issues:
+  discussion:
     types: [pinned]    
 
 jobs:
  sendAnnouncement:
   runs-on: ubuntu-latest
   steps:
-
-  - name: get release/announcement
-    id: rel_annou
-    env:
-      ISSUE_CONTEXT: ${{ toJson(github.event.issue) }}
+  
+  - name: Fetch announcement
+    id: announcement
     run: |
-      echo $ISSUE_CONTEXT > temp_title.txt
-      echo $(cat temp_title.txt)
-      sed -nr 's/.*"title": (.*), "updated.*/\1/p' <temp_title.txt >title.txt
-      echo $(cat title.txt)
-      if [[ $(cat title.txt) == *"Release"* ]]
+      category="${{ github.event.discussion.category.name }}"
+      title="${{ github.event.discussion.title }}"
+      echo "::set-output name=title::${title}"
+      if [[ "${category}" == "Releases" && "${title}" == *"Distro"* ]]
       then
-        echo "::set-output name=release::true"
+        echo "::set-output name=is_distro::true"
       else
-        echo "::set-output name=release::false"
+        echo "::set-output name=is_distro::false"
       fi
 
-  - name: Get summary
+  - name: Fetch summary
     id: summary
-    env:
-      ISSUE_CONTEXT: ${{ toJson(github.event.issue) }}
     run: |
-      echo $ISSUE_CONTEXT > temp.txt
-      sed -nr 's/.*### Brief description of the announcement(.*)### Detailed context.*/\1/p' <temp.txt >temp5.txt
-      echo "::set-output name=summary::$(cat temp5.txt)"
-      
-  - name: Get title
-    id: title
-    env:
-      ISSUE_CONTEXT: ${{ toJson(github.event.issue) }}
-    run: |
-      echo $ISSUE_CONTEXT > temp_title.txt
-      sed -nr 's/.*"title": (.*), "updated.*/\1/p' <temp_title.txt >title.txt
-      echo "::set-output name=title::$(cat title.txt)"
+      echo "${{ github.event.discussion.body }}" > body.txt
+      sed -nr 's/.*### Brief description of the announcement(.*)### Detailed context.*/\1/p' <body.txt >body.txt
+      echo "::set-output name=body::$(cat body.txt)"
 
-  - name: Get description
+  - name: Fetch description
     id: description
-    env:
-      ISSUE_CONTEXT: ${{ toJson(github.event.issue) }}
     run: |
-      echo $ISSUE_CONTEXT > temp.txt
-      sed -nr 's/.*"body": (.*), "closed_at.*/\1/p' <temp.txt >temp5.txt
-      echo "::set-output name=description::$(cat temp5.txt)"  
+      echo "::set-output name=body::"  
 
-  - name: Get current date
+  - name: Fetch current date
     id: date
     run: |
         echo "::set-output name=date::$(date +'%Y%m')"
         echo "::set-output name=date_spelled::$(date +'%B %Y')"
 
   - name: Repository Dispatch
-    uses: peter-evans/repository-dispatch@v1
+    uses: peter-evans/repository-dispatch@v1.1.3
     with:
       token: ${{ secrets.CODE_REPO_ACCESS_TOKEN }}
       repository: icub-tech-iit/code
       event-type: announcement_launched
-      client-payload: '{"description": ${{ steps.description.outputs.description }}, "id": "${{ steps.date.outputs.date }}", "title": ${{ steps.title.outputs.title }}, "date": "${{ steps.date.outputs.date_spelled }}", "summary": "${{ steps.summary.outputs.summary }}", "image": "???", "type" : "announcement_launched", "release": "${{ steps.rel_annou.outputs.release }}"}'
+      client-payload: '{"description": ${{ steps.description.outputs.body }}, "id": "${{ steps.date.outputs.date }}", "title": ${{ steps.announcement.outputs.title }}, "date": "${{ steps.date.outputs.date_spelled }}", "summary": "${{ steps.summary.outputs.body }}", "image": "???", "type" : "announcement_launched", "release": "${{ steps.announcement.outputs.is_distro }}"}'

--- a/.github/workflows/website_webhook.yml
+++ b/.github/workflows/website_webhook.yml
@@ -14,25 +14,18 @@ jobs:
     run: |
       category="${{ github.event.discussion.category.name }}"
       title="${{ github.event.discussion.title }}"
+      body="${{ github.event.discussion.body }}"
+      
       echo "::set-output name=title::${title}"
-      if [[ "${category}" == "Releases" && "${title}" == *"Distro"* ]]
+      echo "::set-output name=summary::${body:0:500}"
+      echo "::set-output name=description::${body}"
+      
+      if [[ "${category}" == "Releases" ]]
       then
-        echo "::set-output name=is_distro::true"
+        echo "::set-output name=is_release::true"
       else
-        echo "::set-output name=is_distro::false"
-      fi
-
-  - name: Fetch summary
-    id: summary
-    run: |
-      echo "${{ github.event.discussion.body }}" > body.txt
-      sed -nr 's/.*### Brief description of the announcement(.*)### Detailed context.*/\1/p' <body.txt >summary.txt
-      echo "::set-output name=body::$(cat summary.txt)"
-
-  - name: Fetch description
-    id: description
-    run: |
-      echo "::set-output name=body::"  
+        echo "::set-output name=is_release::false"
+      fi      
 
   - name: Fetch current date
     id: date
@@ -46,4 +39,4 @@ jobs:
       token: ${{ secrets.CODE_REPO_ACCESS_TOKEN }}
       repository: icub-tech-iit/code
       event-type: announcement_launched
-      client-payload: '{"description": ${{ steps.description.outputs.body }}, "id": "${{ steps.date.outputs.date }}", "title": ${{ steps.announcement.outputs.title }}, "date": "${{ steps.date.outputs.date_spelled }}", "summary": "${{ steps.summary.outputs.body }}", "image": "???", "type" : "announcement_launched", "release": "${{ steps.announcement.outputs.is_distro }}"}'
+      client-payload: '{"description": ${{ steps.announcement.outputs.description }}, "id": "${{ steps.date.outputs.date }}", "title": ${{ steps.announcement.outputs.title }}, "date": "${{ steps.date.outputs.date_spelled }}", "summary": "${{ steps.announcement.outputs.summary }}", "image": "???", "type" : "announcement_launched", "release": "${{ steps.announcement.outputs.is_release }}"}'


### PR DESCRIPTION
This PR updates the action in order to be triggered by discussions.
Indeed, GitHub has made available the [discussions events](https://github.blog/changelog/2021-06-29-github-discussions-events-available-on-github-actions).

To this end, I had to apply some changes.

A couple of notes:
- The part on fetching the description is empty now as it's unclear to me what was done before and how we can adapt it to the [new fields](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#discussion).
- It'd be also convenient (maybe better off with a second PR) to use the latest app-oriented way to dispatch info to `icub-tech-iit/code`.

cc @AlexAntn @vtikha @vvasco @lauracavaliere @ilaria-carlini 