### PR TITLE
Added if statement to handle only a set of discussion categories

### DIFF
--- a/.github/workflows/website_webhook.yml
+++ b/.github/workflows/website_webhook.yml
@@ -7,6 +7,7 @@ on:
 jobs:
  sendAnnouncement:
   runs-on: ubuntu-latest
+  if: github.event.discussion.category.name == 'Announcements' || github.event.discussion.category.name == 'Releases' || github.event.discussion.category.name == 'Research news' || github.event.discussion.category.name == 'Schools and crash courses'
   steps:
   
   - name: Fetch announcement


### PR DESCRIPTION
In this PR we added an **if statement** to the job of this action, in order to be run only if the category discussion belongs to the set of the following categories: **_Announcements_, _Releases_, _Research news_** and **_Schools and crash courses_**.